### PR TITLE
Added php-bcmath as Drupal Commerce requires it.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,6 +95,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     php5-xdebug \
     php5-ssh2 \
     php5-gnupg \
+    php-bcmath \
     blackfire-php \
     # Cleanup
     && DEBIAN_FRONTEND=noninteractive apt-get clean && \


### PR DESCRIPTION
`RuntimeException: The bcmath extension is required by NumberFormatter. in /var/www/docroot/vendor/commerceguys/intl/src/Formatter/NumberFormatter.php:113`